### PR TITLE
Update cli.py

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -75,7 +75,7 @@ def run_cli(  # for local function:
         model_state = dict(model=model, tokenizer=tokenizer, device=device)
         model_state.update(model_dict)
         fun = partial(evaluate, model_state, my_db_state0, selection_docs_state0,
-                      **get_kwargs(evaluate, exclude_names=['model_state', 'my_db_state',
+                      **get_kwargs(evaluate, exclude_names=['model_state', 'my_db_state', 'requests_state',
                                                             'selection_docs_state'] + eval_func_param_names,
                                    **locals()))
 


### PR DESCRIPTION
I was having this issue when trying `--cli=True`

```bash

Traceback (most recent call last):
  File "C:\Users\William\Documents\h2ogpt\generate.py", line 16, in <module>
    entrypoint_main()
  File "C:\Users\William\Documents\h2ogpt\generate.py", line 12, in entrypoint_main
    H2O_Fire(main)
  File "C:\Users\William\Documents\h2ogpt\src\utils.py", line 57, in H2O_Fire
    fire.Fire(component=component, command=args)
  File "C:\Users\William\Documents\h2ogpt\.venv\Lib\site-packages\fire\core.py", line 141, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\William\Documents\h2ogpt\.venv\Lib\site-packages\fire\core.py", line 475, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
                                ^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\William\Documents\h2ogpt\.venv\Lib\site-packages\fire\core.py", line 691, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
                ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\William\Documents\h2ogpt\src\gen.py", line 781, in main
    return run_cli(**get_kwargs(run_cli, exclude_names=['model_state0'], **locals()))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\William\Documents\h2ogpt\src\cli.py", line 78, in run_cli
    **get_kwargs(evaluate, exclude_names=['model_state', 'my_db_state',
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\William\Documents\h2ogpt\src\utils.py", line 910, in get_kwargs
    assert not missing_kwargs, "Missing %s" % missing_kwargs
AssertionError: Missing ['requests_state']
```

And looking at `gen.py`, `requests_state` was added a few days ago. So adding it in exclude_names seams to fix the issue